### PR TITLE
Removed determine data source, change saving images

### DIFF
--- a/Headers/json.h
+++ b/Headers/json.h
@@ -7,12 +7,11 @@ class json : public QObject
     Q_OBJECT
 public:
     explicit json(QObject *parent = 0);
-    QString determineDataSource(QByteArray);
     QStringList getStreamerFollowedList(QByteArray);
     ~json();
-    QStringList getStreamData(QByteArray data);
-    QList<QStringList> getFeaturedStreamData(QByteArray data);
-    QList<QStringList> getTopGames(QByteArray data);
+    QStringList getStreamData(QByteArray);
+    QList<QStringList> getFeaturedStreamData(QByteArray);
+    QList<QStringList> getTopGames(QByteArray);
 signals:
 
 public slots:

--- a/Headers/mainwindow.h
+++ b/Headers/mainwindow.h
@@ -20,11 +20,11 @@ public:
 
     void changeStatusBar();
 private slots:
-    void requestReady(QByteArray data);
+    void requestReady(QByteArray,QString);
     void on_actionAdd_User_triggered();
     void on_actionExit_triggered();
     void on_pushButton_clicked();
-    void on_tabWidget_currentChanged(int index);
+    void on_tabWidget_currentChanged(int);
 
 private:
     Ui::MainWindow *ui;

--- a/Headers/networkoperations.h
+++ b/Headers/networkoperations.h
@@ -19,8 +19,9 @@ public:
     void makeFollowRequest(QString);
     int checkNetworkConnection();
     void makeRequest(QString url);
+    void makeImageRequest(QString,QString);
 signals:
-    void dataReady(QByteArray);
+    void dataReady(QByteArray,QString);
 public slots:
     void doneReading(QNetworkReply *reply);
     void timedFollowRequest();

--- a/Sources/json.cpp
+++ b/Sources/json.cpp
@@ -15,23 +15,6 @@ json::~json()
 
 }
 
-QString json::determineDataSource(QByteArray data)
-{
-    QJsonDocument jsonData = QJsonDocument::fromJson(data);
-    if (!jsonData.isEmpty())
-    {
-        QJsonObject json = jsonData.object();
-        QStringList keys = json.keys();
-        //Last value in the array is the type of data.
-        int last = keys.length()-1;
-        return keys[last];
-    }
-    else
-    {
-        return "image";
-    }
- }
-
 QStringList json::getStreamerFollowedList(QByteArray data)
 {
     QJsonDocument jsonData = QJsonDocument::fromJson(data);

--- a/Sources/mainwindow.cpp
+++ b/Sources/mainwindow.cpp
@@ -7,7 +7,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    connect((&networking),SIGNAL(dataReady(QByteArray)),this,SLOT(requestReady(QByteArray)));
+    connect((&networking),SIGNAL(dataReady(QByteArray,QString)),this,SLOT(requestReady(QByteArray,QString)));
     this->changeStatusBar();
 
 
@@ -18,10 +18,9 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
-void MainWindow::requestReady(QByteArray data)
+void MainWindow::requestReady(QByteArray data, QString requestType)
 {
-
-    QString jsonType = jsonParser.determineDataSource(data);
+    QString jsonType = requestType;
 
     if (jsonType == "follows")
     {
@@ -47,9 +46,11 @@ void MainWindow::requestReady(QByteArray data)
         topGames << jsonParser.getTopGames(data);
         qDebug() << topGames;
     }
-    else if (jsonType == "image")
+    else if (jsonType.contains("image:"))
     {
-        image.saveScaledImage("/Users/Wizard/test", data, 30, 30);
+        QStringList imageFilename = jsonType.split(":");
+        QString saveDir = "/Users/Wizard/" + imageFilename[1];
+        image.saveScaledImage(saveDir, data, 30, 30);
     }
     else
     {
@@ -72,9 +73,8 @@ void MainWindow::on_pushButton_clicked()
 //    networking.makeStreamRequest("dotastarladder_en");
 //    networking.makeStreamRequest("L0veWizard");
 //    networking.makeFeaturedRequest();
-//    networking.makeFollowRequest("L0veWizard");
 //    networking.makeTopGamesRequest();
-    networking.makeRequest("http://static-cdn.jtvnw.net/jtv_user_pictures/richard_hammer-profile_image-cbcf6eda2ff6fc2b-300x300.jpeg");
+    networking.makeImageRequest("http://static-cdn.jtvnw.net/jtv_user_pictures/richard_hammer-profile_image-cbcf6eda2ff6fc2b-300x300.jpeg","richard_hammer");
 }
 
 void MainWindow::on_tabWidget_currentChanged(int index)

--- a/Sources/networkoperations.cpp
+++ b/Sources/networkoperations.cpp
@@ -24,13 +24,15 @@ void networkOperations::makeRequest(QString url)
 void networkOperations::doneReading(QNetworkReply *reply)
 {
     QByteArray replyData = reply->readAll();
-    emit(dataReady(replyData));
+    QString requestType = this->objectName();
+    emit(dataReady(replyData,requestType));
 }
 
 void networkOperations::timedFollowRequest()
 {
     QString username = "L0veWizard";
     QString url = "https://api.twitch.tv/kraken/users/" + username + "/follows/channels";
+    this->setObjectName("follow");
     this->makeRequest(url);
 
 }
@@ -38,24 +40,35 @@ void networkOperations::timedFollowRequest()
 void networkOperations::makeFollowRequest(QString username)
 {
     QString url = "https://api.twitch.tv/kraken/users/" + username + "/follows/channels";
+    this->setObjectName("follow");
     this->makeRequest(url);
 }
 
 void networkOperations::makeStreamRequest(QString username)
 {
     QString url = "https://api.twitch.tv/kraken/streams/" + username;
+    this->setObjectName("stream");
     this->makeRequest(url);
 }
 
 void networkOperations::makeFeaturedRequest()
 {
     QString url = "https://api.twitch.tv/kraken/streams/featured";
+    this->setObjectName("featured");
     this->makeRequest(url);
 }
 
 void networkOperations::makeTopGamesRequest()
 {
     QString url = "https://api.twitch.tv/kraken/games/top";
+    this->setObjectName("top");
+    this->makeRequest(url);
+}
+
+void networkOperations::makeImageRequest(QString url,QString username)
+{
+    QString imageFilename = "image:" + username;
+    this->setObjectName(imageFilename);
     this->makeRequest(url);
 }
 


### PR DESCRIPTION
Before network requests were parsed to determine what type of data it
was.  Now this is tracked through an object name being passed along with
the request.  This allows for username to be passed along for saving
images.
